### PR TITLE
[B03580] Defaults on submitted trial requests

### DIFF
--- a/resources/api/index.php
+++ b/resources/api/index.php
@@ -60,6 +60,7 @@ Flight::route('/proposeResource/', function(){
         $resource->$fieldName = Flight::request()->data->$fieldName;
     }
 
+    // TAMU Customization - Use explicitly defined Type and Format defaults, ensuring that a default workflow is properly started.
     $resourceTypeObj = new ResourceType();
     $resourceType = $resourceTypeObj->getResourceTypeIDByName('Database');
     if ($resourceType) {

--- a/resources/api/index.php
+++ b/resources/api/index.php
@@ -59,6 +59,19 @@ Flight::route('/proposeResource/', function(){
     foreach ($fieldNames as $fieldName) {
         $resource->$fieldName = Flight::request()->data->$fieldName;
     }
+
+    $resourceTypeObj = new ResourceType();
+    $resourceType = $resourceTypeObj->getResourceTypeIDByName('Database');
+    if ($resourceType) {
+        $resource->resourceTypeID = $resourceType;
+    }
+
+    $resourceFormatObj = new ResourceFormat();
+    $resourceFormat = $resourceFormatObj->getResourceFormatIDByName('Electronic');
+    if ($resourceFormat) {
+        $resource->resourceFormatID = $resourceFormat;
+    }
+
     try {
         $resource->save();
         $resourceID = $resource->primaryKey;


### PR DESCRIPTION
When each of Resource Type "Database" and Resource Format "Electronic" are defined, assign them as the default.

This effectively fixes D-01195, which seems to require "Resource Type" and "Resource Format" to be non-null/non-empty strings to trigger the start of a workflow.
