### PR TITLE
Re-auth with saml sp when coral session is not open

### DIFF
--- a/auth/index.php
+++ b/auth/index.php
@@ -23,6 +23,11 @@ session_start();
 include_once 'directory.php';
 $util = new Utility();
 
+if (isset($_GET['service'])){
+	$service = $_GET['service'];
+}else{
+	$service = $util->getCORALURL();
+}
 
 /** TAMU Customization - bypass standard Coral auth and use our custom saml implementation for authentication */
 $config = new Configuration();
@@ -32,12 +37,6 @@ if($config->tamu->useSAML == 'Y') {
 }
 exit;
 /** End TAMU Customization - bypass standard Coral auth and use our custom saml implementation for authentication */
-
-if (isset($_GET['service'])){
-	$service = $_GET['service'];
-}else{
-	$service = $util->getCORALURL();
-}
 
 $errorMessage = '';
 $message='&nbsp;';

--- a/custom/lib/saml.start.php
+++ b/custom/lib/saml.start.php
@@ -23,23 +23,19 @@ try {
     if (!isset($config)) {
         throw new SAMLException("Coral config is missing");
     }
+    //$service should always be set in the auth index file but just in case
+    if (!isset($service)) {
+        $service = isset($_GET['service']) ?$_GET['service'] : $util->getCORALURL();
+    }
+    $samlUser = new Classes\SAMLUser($config, $util, new Session());
 
-    if (!array_key_exists('loginID', $_SESSION) || empty($_SESSION['loginID'])) {
-        if (isset($_GET['service'])) {
-            $service = $_GET['service'];
-        } else {
-            $service = $util->getCORALURL();
+    if (!empty($_POST['SAMLResponse'])) {
+        if (is_string($_POST['SAMLResponse'])) {
+            $samlUser->processLogIn();
+            exit;
         }
-        $samlUser = new Classes\SAMLUser($config, $util, new Session());
-
-        if (!empty($_POST['SAMLResponse'])) {
-            if (is_string($_POST['SAMLResponse'])) {
-                $samlUser->processLogIn();
-                exit;
-            }
-        } else {
-            $samlUser->initiateLogIn($service);
-        }
+    } else {
+        $samlUser->initiateLogIn($service);
     }
 } catch (SAMLException $e) {
     echo 'There was an error with the login process.';

--- a/custom/lib/saml.start.php
+++ b/custom/lib/saml.start.php
@@ -25,7 +25,7 @@ try {
     }
     //$service should always be set in the auth index file but just in case
     if (!isset($service)) {
-        $service = isset($_GET['service']) ?$_GET['service'] : $util->getCORALURL();
+        $service = isset($_GET['service']) ? $_GET['service'] : $util->getCORALURL();
     }
     $samlUser = new Classes\SAMLUser($config, $util, new Session());
 


### PR DESCRIPTION
When the local Coral session is expired or otherwise not open, the saml logic will exit rather than renew auth with the SAML provider because the user will still have a session loginID in this case.

Removing the check for loginID in the php session allows the auth renewal process to take place when the user has a session loginID but no open Coral session.

The service var logic has been moved up in auth/index so the variable is available in saml.start.php, but the formatting style has been preserved in auth/index to minimize changes in an upstream file.